### PR TITLE
Support GHC 9.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         # We must always use the latest version of cabal because
         # otherwise ghc-paths, which is a dependency of doctest,
         # can't be configured.
-        cabal: ["3.10"]
+        cabal: ["3.16"]
         ghc:
           - "8.6.5"
           - "8.8.3"
@@ -33,6 +33,7 @@ jobs:
           - "9.8.1"
           - "9.10.1"
           - "9.12.1"
+          - "9.14.1"
 
     steps:
     - uses: actions/checkout@v4

--- a/cabal.project
+++ b/cabal.project
@@ -3,3 +3,5 @@ packages:
     trial-example
     trial-optparse-applicative
     trial-tomland
+
+allow-newer: boring:base

--- a/trial-example/trial-example.cabal
+++ b/trial-example/trial-example.cabal
@@ -26,7 +26,7 @@ source-repository head
 
 
 common common-options
-  build-depends:       base >= 4.12.0.0 && < 4.22
+  build-depends:       base >= 4.12.0.0 && < 4.23
                      , trial
                      , trial-optparse-applicative
                      , trial-tomland

--- a/trial-optparse-applicative/trial-optparse-applicative.cabal
+++ b/trial-optparse-applicative/trial-optparse-applicative.cabal
@@ -26,7 +26,7 @@ source-repository head
   location:            https://github.com/kowainik/trial.git
 
 common common-options
-  build-depends:       base >= 4.12.0.0 && < 4.22
+  build-depends:       base >= 4.12.0.0 && < 4.23
 
   ghc-options:         -Wall
                        -Wcompat

--- a/trial-tomland/trial-tomland.cabal
+++ b/trial-tomland/trial-tomland.cabal
@@ -26,7 +26,7 @@ source-repository head
   location:            https://github.com/kowainik/trial.git
 
 common common-options
-  build-depends:       base >= 4.12.0.0 && < 4.22
+  build-depends:       base >= 4.12.0.0 && < 4.23
 
   ghc-options:         -Wall
                        -Wcompat

--- a/trial/trial.cabal
+++ b/trial/trial.cabal
@@ -55,7 +55,7 @@ source-repository head
   location:            https://github.com/kowainik/trial.git
 
 common common-options
-  build-depends:       base >= 4.12.0.0 && < 4.22
+  build-depends:       base >= 4.12.0.0 && < 4.23
 
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
Use cabal.project to relax boring's bounds.  This will allow CI to run, but not leak into released sdists.